### PR TITLE
Lower initial zoom

### DIFF
--- a/lode-viewer/store.js
+++ b/lode-viewer/store.js
@@ -25,7 +25,7 @@ export default class Store {
 	}
 	
 	static get Zoom() {
-		return localStorage.getItem("lode-zoom") || 3;
+		return localStorage.getItem("lode-zoom") || 2;
 	}
 	
 	static set Zoom(value) {

--- a/mapbox-tools/components/map.js
+++ b/mapbox-tools/components/map.js
@@ -36,12 +36,16 @@ export default class Map extends Evented {
 		
 		this.layers = [];
 		this.original = {};
+		this.maxExtent = [[-162.0, 41.0], [-32.0, 83.5]];
 		this.style = options.style;
 		
 		this.click = this.OnLayerClick_Handler.bind(this);;
 		
 		this.map = new mapboxgl.Map(options); 
 		
+		// Set the maximum bounds of the map
+		this.SetMaxBounds(this.maxExtent);
+
 		this.map.once('styledata', this.OnceStyleData_Handler.bind(this));
 		
 		// this.map.on('click', this.click);
@@ -164,7 +168,11 @@ export default class Map extends Evented {
 	FitBounds(bounds, options) {		
 		this.map.fitBounds(bounds, options);
 	}
-	
+
+	SetMaxBounds(bounds) {
+		this.map.setMaxBounds(bounds);
+	}
+
 	SetStyle(style) {
 		this.style = style;
 		


### PR DESCRIPTION
fix #20 

* Added support for setMaxBounds in map.js
* Set the max bounds of the map to an extent which encompasses all of Canada, and neighbouring water masses. 
* Updated default zoom level from 3 to 2 for lode-viewer. This ensures that on fresh loads of the application is fully zoomed out to show more of Canada. 