### PR TITLE
Fix relative paths in roll-up configuration scripts 

### DIFF
--- a/config/population-viewer-prd.rollup.js
+++ b/config/population-viewer-prd.rollup.js
@@ -3,7 +3,7 @@ import babel from 'rollup-plugin-babel';
 export default {
     input: '../web-mapping-dev/population-viewer/main.js',
     output: {
-        file: '../../web-mapping-prd/population-viewer/main.min.js',
+        file: '../web-mapping-prd/population-viewer/main.min.js',
         format: 'iife',
         name: 'bundle'
     },

--- a/config/population-viewer-prd.rollup.js
+++ b/config/population-viewer-prd.rollup.js
@@ -1,7 +1,7 @@
 import babel from 'rollup-plugin-babel';
 
 export default {
-    input: '../population-viewer/main.js',
+    input: '../web-mapping-dev/population-viewer/main.js',
     output: {
         file: '../../web-mapping-prd/population-viewer/main.min.js',
         format: 'iife',

--- a/config/proximity-viewer-prd.rollup.js
+++ b/config/proximity-viewer-prd.rollup.js
@@ -3,7 +3,7 @@ import babel from 'rollup-plugin-babel';
 export default {
     input: '../web-mapping-dev/proximity-viewer/main.js',
     output: {
-        file: '../../web-mapping-prd/proximity-viewer/main.min.js',
+        file: '../web-mapping-prd/proximity-viewer/main.min.js',
         format: 'iife',
         name: 'bundle'
     },

--- a/config/proximity-viewer-prd.rollup.js
+++ b/config/proximity-viewer-prd.rollup.js
@@ -1,7 +1,7 @@
 import babel from 'rollup-plugin-babel';
 
 export default {
-    input: '../proximity-viewer/main.js',
+    input: '../web-mapping-dev/proximity-viewer/main.js',
     output: {
         file: '../../web-mapping-prd/proximity-viewer/main.min.js',
         format: 'iife',


### PR DESCRIPTION
Small tweak to the roll-up configuration scripts to ensure build process is consistent for all viewers. Now all viewers are built from the root web-mapping-dev directory using the `npm run <script-name>`.

Tweaks were made to the relative paths pointing to the entry points for both the proximity-viewer and population-viewer. 